### PR TITLE
Extend Playground to work with Text-Areas

### DIFF
--- a/templates/creative/seo-banner/index.pug
+++ b/templates/creative/seo-banner/index.pug
@@ -14,22 +14,43 @@ block content
             div.copyable-inner
               include _seo-banner
       .row
-        .col.xs
+        .col.xs-12.sm-6
           div.playground-control
             label(for="seo_title") SEO Title:
-              input#seo_title.playground-item(
+              textarea#seo_title.playground-item(
                 data-target=".seo-banner_title"
                 type="text"
                 value = "Pillows & Cushions"
               )
-        .col.xs
+        .col.xs-12.sm-6
           div.playground-control
             label(for="seo_copy") SEO Copy:
-              input#seo_copy.playground-item(
+              textarea#seo_copy.playground-item(
                 data-target=".seo-banner_copy"
                 type="text"
                 value = "Have a soft spot for comfy, cushiony throw pillows? We do, too. With our selection of decorative pillows in textured, embellished, solid and patterned designs, adding the final flourish to your look is simple. And don’t forget about outdoor pillows, featuring UV-treated fabric. Toss in a new pillow or two today."
               )
+
+  style(type='text/css').
+    .col.xs-6 {
+      padding: 1em;
+    }
+    #seo_copy, #seo_title {
+      display:flex;
+      align-items:center;
+      width:100%;
+      max-width:100%;
+   }
+
+   #seo_copy {
+      min-height:160px;
+   }
+
+   .copyable-inner {
+      /* simulates actual width on desktop pier1.com */
+      max-width: 739px;
+      margin: 0 auto;
+   }
 
 block scripts
   script.

--- a/templates/js/playground.jquery.js
+++ b/templates/js/playground.jquery.js
@@ -27,6 +27,7 @@
                 base.$el.on('click', ".playground-list_item", updateTarget);
             } else {
                 base.initText();
+                base.$el.html(base.$el[0].getAttribute('value'));
                 base.$el.on('input', updateTarget);
             }
             
@@ -93,6 +94,7 @@
 
         function updateTarget(){
         	var val, display, idx;
+
 
         	if ( arguments[0].type === 'input' || arguments[0].type === 'change' || arguments[0].type === 'click') {
         		idx = arguments[0].currentTarget.value || arguments[0].currentTarget.getAttribute('value');


### PR DESCRIPTION
Can now use text-areas with playground. Uses same configuration as inputs. 

Additionally, the SEO Banner example was updated to take advantage of this new functionality.