### PR TITLE
fix(Buttons): Fix success buttons not entering success state

### DIFF
--- a/templates/components/buttons/index.pug
+++ b/templates/components/buttons/index.pug
@@ -42,7 +42,7 @@ block content
     +exampleWithCode
       include _buttons-dynamic.pug
 
-    h3 Success
+    h3#success Success
     +exampleWithCode
       include _buttons-dynamic-success.pug
 


### PR DESCRIPTION
Buttons were not being sent the success message after completion. For demonstration purposes, this
is done by attaching an id attribute in the html. Readding the id attribute (which had been removed).