### PR TITLE
refactor(Images): Remove unneeded style

### DIFF
--- a/rocketbelt/components/images/_images-lazyload.scss
+++ b/rocketbelt/components/images/_images-lazyload.scss
@@ -50,17 +50,3 @@
     }
   }
 }
-
-.lazyload {
-  display: flex;
-  flex: 1;
-  margin-top: 10vh;
-  margin-bottom: 90vh;
-  min-width: 20vw;
-  min-height: 20vw;
-  border-radius: 2px;
-  background-color: color(gray, plus4);
-
-  justify-content: center;
-  align-items: center;
-}


### PR DESCRIPTION
`.lazyload' style wasn't referenced in any JS or class attributions. Removed to avoid potential styling conflicts on other sites.