### PR TITLE
refactor(Dialogs): Convert dialogs to a min/max-width approach.

### DIFF
--- a/rocketbelt/components/dialogs/_dialog-base.scss
+++ b/rocketbelt/components/dialogs/_dialog-base.scss
@@ -86,8 +86,9 @@
   left: 50%;
   z-index: 3;
   overflow-y: auto;
+  min-width: 95%;
+  max-width: 990px;
   max-height: 90%;
-  width: 95%;
   border-radius: 2px;
   background-color: color(white);
   transform: translate3d(-50%, -50%, 0);
@@ -99,11 +100,11 @@
   }
 
   @include media('>=md') {
-    width: 60%;
+    min-width: 75%;
   }
 
   @include media('>=lg') {
-    width: 40%;
+    min-width: 40%;
   }
 }
 

--- a/rocketbelt/components/dialogs/_dialog-max.scss
+++ b/rocketbelt/components/dialogs/_dialog-max.scss
@@ -34,7 +34,6 @@
     }
 
     .dialog_content {
-      position: absolute;
       top: 0;
       right: 0;
       bottom: 0;

--- a/rocketbelt/components/dialogs/_dialog-max.scss
+++ b/rocketbelt/components/dialogs/_dialog-max.scss
@@ -39,14 +39,15 @@
       right: 0;
       bottom: 0;
       left: 0;
+      min-width: 100%;
+      max-width: 100%;
       max-height: 100%;
-      width: 100%;
       transform: none;
 
       @include media('>=md') {
         right: 10%;
         left: 10%;
-        width: 80%;
+        min-width: 80%;
       }
     }
   }

--- a/rocketbelt/components/dialogs/_dialog-sheet.scss
+++ b/rocketbelt/components/dialogs/_dialog-sheet.scss
@@ -26,7 +26,8 @@
       right: 0;
       bottom: 0;
       left: 0;
-      width: 100%;
+      min-width: 100%;
+      max-width: 100%;
       transform: none;
       animation: dialog-sheet-in 300ms ease-in-out;
     }

--- a/rocketbelt/components/dialogs/_dialog-sheet.scss
+++ b/rocketbelt/components/dialogs/_dialog-sheet.scss
@@ -21,7 +21,6 @@
 .dialog {
   &.dialog-sheet {
     .dialog_content {
-      position: absolute;
       top: auto;
       right: 0;
       bottom: 0;


### PR DESCRIPTION
Wanted to convert the width over to a min/max approach to help limit widths (standard dialogs to be more specific) on bigger monitors. Also bumped up the min-width on tablet standard dialogs to take up a little more space.