### PR TITLE
iOS Dialog Fix

### DIFF
--- a/rocketbelt/components/dialogs/_dialog-base.scss
+++ b/rocketbelt/components/dialogs/_dialog-base.scss
@@ -43,6 +43,11 @@
 .is-dialog-open {
   overflow: hidden;
 
+  // Resolves iOS bug
+  position: fixed;
+  left: 0;
+  right: 0;
+
   .dialog_blur {
     filter: blur(5px);
   }

--- a/rocketbelt/components/dialogs/rocketbelt.dialogs.js
+++ b/rocketbelt/components/dialogs/rocketbelt.dialogs.js
@@ -2,6 +2,7 @@
 $(function () {
   var options = initOptions();
   var focusedBeforeDialog;
+  var scrollBeforeDialog;
   // IE doesn't apply append var to the global scope.
   $cache = {
     appendTo: $(options.appendTo),
@@ -183,6 +184,10 @@ $(function () {
   function open() {
     if ($cache.appendTo.hasClass('is-dialog-open')) return;
 
+    // Preserve scroll position
+    scrollBeforeDialog = $(window).scrollTop();
+    $cache.appendTo.css('top', '-' + scrollBeforeDialog + 'px');
+
     $cache.appendTo.addClass('is-dialog-open');
     $cache.blurElement.addClass('dialog_blur').attr('aria-hidden', true);
     $cache.rbDialog.removeAttr('aria-hidden');
@@ -201,6 +206,11 @@ $(function () {
     if ($cache.rbDialog[0].hasAttribute('aria-hidden')) return;
 
     $cache.appendTo.removeClass('is-dialog-open');
+
+    // Preserve scroll position
+    $cache.appendTo.css('top', '0');
+    $(window).scrollTop(scrollBeforeDialog);
+
     $cache.blurElement.removeClass('dialog_blur').removeAttr('aria-hidden');
     $cache.rbDialog.attr('aria-hidden', 'true');
     focusedBeforeDialog && focusedBeforeDialog.focus();


### PR DESCRIPTION
Dialogs with `position: fixed` are broken on iOS. [see stackoverflow post](https://stackoverflow.com/questions/46567233/how-to-fix-the-ios-11-input-element-in-fixed-modals-bug)

The current solution is to add `position: fixed` to the body (or out container) and preserve the scroll position using javascript.