### PR TITLE
inverted background to transparent

### DIFF
--- a/rocketbelt/components/busy-indicators/_busy-indicators-component.scss
+++ b/rocketbelt/components/busy-indicators/_busy-indicators-component.scss
@@ -46,6 +46,8 @@
 
   &.is-busy-inverted {
     .is-busy_overlay {
+      background-color: transparent;
+      
       .dot {
         $c: rgba(color(white), 0.9);
         background-color: $c;


### PR DESCRIPTION
the inverted background was being derived from the non inverted background (background-color: rgba(color(white), 0.7);) which is weird and probably unintended with white 0.9 dots