### PR TITLE
Img Lazy Load Changes

### DIFF
--- a/rocketbelt/components/images/_images-lazyload.scss
+++ b/rocketbelt/components/images/_images-lazyload.scss
@@ -47,6 +47,11 @@
     &.lazyload-small {
       opacity: 0.5;
       transition: opacity 200ms ease-in-out;
+      
+      &.errored{
+        opacity: 1;
+        height: 100%;
+        width: 100%;
     }
   }
 }

--- a/rocketbelt/components/images/_images-lazyload.scss
+++ b/rocketbelt/components/images/_images-lazyload.scss
@@ -46,12 +46,15 @@
 
     &.lazyload-small {
       opacity: 0.5;
-      transition: opacity 200ms ease-in-out;
-      
-      &.errored{
-        opacity: 1;
-        height: 100%;
-        width: 100%;
+      transition: opacity 200ms ease-in-out;     
     }
-  }
+    
+    &.errored{
+      background: none;
+      animation: none;
+      
+      & img.lazyload-small{
+        opacity: 1;
+      }
+    }
 }

--- a/rocketbelt/components/images/rocketbelt.images-lazyload.js
+++ b/rocketbelt/components/images/rocketbelt.images-lazyload.js
@@ -12,9 +12,9 @@
         small.classList.add('loaded');
       };
       img.onerror = function(){
-		    small.src = wrapper.dataset.srcErr;
-        small.classList.add('errored');
-	    };
+	small.src = wrapper.dataset.srcErr;
+        wrapper.classList.add('errored');
+      };
     });
 
     $('.lazyload-wrapper .lazyload-small').each(function () {

--- a/rocketbelt/components/images/rocketbelt.images-lazyload.js
+++ b/rocketbelt/components/images/rocketbelt.images-lazyload.js
@@ -1,4 +1,4 @@
-(function () {
+(function ($) {
   var ctrl = new ScrollMagic.Controller();
 
   $(document).ready(function () {
@@ -11,6 +11,10 @@
       img.onload = function () {
         small.classList.add('loaded');
       };
+      img.onerror = function(){
+		    small.src = wrapper.dataset.srcErr;
+        small.classList.add('errored');
+	    };
     });
 
     $('.lazyload-wrapper .lazyload-small').each(function () {
@@ -34,4 +38,4 @@
         .addTo(ctrl);
     });
   });
-})();
+})(jQuery);


### PR DESCRIPTION
I do not know if the base use case of lazy loading was intended to support failed image loading but i think it's a useful feature. I was going to add an example, but i couldn't feel confident in what i was adding to the template, so that might be something that needs to be added later.

The class is intended to stop the background/animation on the wrapper after the images fail to load so it's not running forever on top of the potential failed image.

as usual, modifications to this are welcome, and if anything is unclear please let me know.