### PR TITLE
Remove justify-content from non-dismissable alerts

### DIFF
--- a/rocketbelt/components/alerts/_alerts.scss
+++ b/rocketbelt/components/alerts/_alerts.scss
@@ -6,6 +6,7 @@ $message-families: (success, error, warning, info);
   padding: 0.5rem;
   border: 1px solid;
   border-radius: 2px;
+  align-items: center;
 }
 
 
@@ -75,7 +76,6 @@ $message-families: (success, error, warning, info);
 .message-dismissable {
 
   justify-content: space-between;
-  align-items: center;
   
   .message-dismissable_close {
     display: flex;

--- a/rocketbelt/components/alerts/_alerts.scss
+++ b/rocketbelt/components/alerts/_alerts.scss
@@ -6,9 +6,6 @@ $message-families: (success, error, warning, info);
   padding: 0.5rem;
   border: 1px solid;
   border-radius: 2px;
-
-  justify-content: space-between;
-  align-items: center;
 }
 
 
@@ -76,6 +73,10 @@ $message-families: (success, error, warning, info);
 }
 
 .message-dismissable {
+
+  justify-content: space-between;
+  align-items: center;
+  
   .message-dismissable_close {
     display: flex;
     margin: -0.375rem;


### PR DESCRIPTION
When multiple elements are inside a message-flash, the `justify-content: space-between` was causing this:

![Space between](https://i.imgur.com/TOUw55b.png)