### PR TITLE
Change innerHTML to insertAdjacentHTML

### DIFF
--- a/rocketbelt/components/busy-indicators/rocketbelt.progress-indicators.js
+++ b/rocketbelt/components/busy-indicators/rocketbelt.progress-indicators.js
@@ -27,7 +27,7 @@
               ${markup}\
             </${elType}>`;
 
-          el.innerHTML = el.innerHTML + fragment;
+          el.insertAdjacentHTML('beforeend', fragment);
         }
       } else {
         // If "is-busy" was removed


### PR DESCRIPTION
### Summary

Allows JS bindings to persist while using busy indicators as mentioned #178