### PR TITLE
Check for is-busy class addition instead of existence

### DIFF
--- a/rocketbelt/components/busy-indicators/rocketbelt.progress-indicators.js
+++ b/rocketbelt/components/busy-indicators/rocketbelt.progress-indicators.js
@@ -6,13 +6,14 @@
     for (let k = 0; k < mutationsLen; k++) {
       const mutation = mutations[k];
       const el = mutation.target;
+      const oldValue = mutation.oldValue;
 
-      setIndicators(el);
+      setIndicators(el, oldValue);
     }
   }
 
-  function setIndicators(el) {
-    if (el.classList && el.classList.contains('is-busy')) {
+  function setIndicators(el, oldValue) {
+    if ((!oldValue || !oldValue.match(/\bis-busy\b/)) && el.classList && el.classList.contains('is-busy')) {
       // If "is-busy" was added, do the decoratin'
       if (el.getElementsByClassName('is-busy_overlay').length === 0) {
         // Only add overlay if one doesn't already exist


### PR DESCRIPTION
### Summary
The mutation observer for busy indicators checks if the `is-busy` class exists but not if the current mutation is the one that added it. Meaning that when _any_ class is added to the observed element while it has class `is-busy`, the code is executed for adding the indicator markup.

This may be by design, let me know
