### PR TITLE
Touch Devices and Forms and RB Template Fix

### DIFF
--- a/gulp-tasks/watch.js
+++ b/gulp-tasks/watch.js
@@ -21,7 +21,7 @@
   module.exports = (gulp, plugins, config) => {
     return () => {
       gulp.watch(['./rocketbelt/**/*.scss', './templates/scss/**/*.scss'], ['styles']);
-      gulp.watch(['./templates/**/*.pug'], ['views']);
+      gulp.watch(['./templates/**/*.pug'], ['views', 'link-templates']);
       gulp.watch(['./rocketbelt/**/*.js'], ['copy-js', 'uglify']);
       gulp.watch(config.buildPath + '/**/*.html')
         .on('change', plugins.browserSync.reload);

--- a/rocketbelt/components/buttons/_buttons-anchor.pug
+++ b/rocketbelt/components/buttons/_buttons-anchor.pug
@@ -1,4 +1,5 @@
 a.button.button-lg.button-primary(href='#', role='button') Anchor Button
 a.button(disabled, href='#', role='button').button-lg.button-primary Disabled
-a.button(href='#', role='button') Anchor Button
-a.button.button-sm.button-primary(href='#', role='button') Anchor Button
+a.button(href='#', role='button') Medium Anchor
+a.button.button-sm.button-primary(href='#', role='button') Small Anchor
+a.button.button-mini.button-primary(href='#', role='button') Mini Anchor

--- a/rocketbelt/components/buttons/_buttons-dynamic-success.pug
+++ b/rocketbelt/components/buttons/_buttons-dynamic-success.pug
@@ -1,3 +1,4 @@
 button.button-lg.button-primary.button-dynamic(data-busy-text='Adding to Basket', data-success-text='Added') Add to Basket
 button.button.button-primary.button-dynamic Medium
 button.button-sm.button-primary.button-dynamic Small
+button.button-mini.button-primary.button-dynamic Mini

--- a/rocketbelt/components/buttons/_buttons-dynamic.pug
+++ b/rocketbelt/components/buttons/_buttons-dynamic.pug
@@ -1,3 +1,4 @@
 button.button-lg.button-primary.button-dynamic(data-busy-text='Adding to Basket') Add to Basket
 button.button.button-primary.button-dynamic Medium
 button.button-sm.button-primary.button-dynamic Small
+button.button-mini.button-primary.button-dynamic Mini

--- a/rocketbelt/components/buttons/_buttons-link.pug
+++ b/rocketbelt/components/buttons/_buttons-link.pug
@@ -1,4 +1,5 @@
 button.button-lg.button-link Link Button
 button(disabled).button-lg.button-link Disabled
-button.button-md.button-link Link Button
-button.button-sm.button-link Link Button
+button.button-md.button-link Medium Link
+button.button-sm.button-link Small Link
+button.button-mini.button-link Mini Link

--- a/rocketbelt/components/buttons/_buttons-primary.pug
+++ b/rocketbelt/components/buttons/_buttons-primary.pug
@@ -2,3 +2,4 @@ button.button-lg.button-primary Primary
 button(disabled).button-lg.button-primary Disabled
 button.button.button-primary Medium
 button.button-sm.button-primary Small
+button.button-mini.button-primary Mini

--- a/rocketbelt/components/buttons/_buttons-secondary.pug
+++ b/rocketbelt/components/buttons/_buttons-secondary.pug
@@ -2,3 +2,4 @@ button.button-lg.button-secondary Secondary
 button(disabled).button-lg.button-secondary Disabled
 button.button.button-secondary Medium
 button.button-sm.button-secondary Small
+button.button-mini.button-secondary Mini

--- a/rocketbelt/components/buttons/_buttons-text.pug
+++ b/rocketbelt/components/buttons/_buttons-text.pug
@@ -1,4 +1,5 @@
 button.button-lg.button-text Text Button
 button(disabled).button-lg.button-text Disabled
-button.button-md.button-text Text Button
-button.button-sm.button-text Text Button
+button.button-md.button-text Medium Text
+button.button-sm.button-text Small Text
+button.button-mini.button-text Mini Text

--- a/rocketbelt/components/buttons/_buttons.scss
+++ b/rocketbelt/components/buttons/_buttons.scss
@@ -82,6 +82,14 @@ button {
   text-transform: none;
 }
 
+.button-mini {
+  @include button-size(mini);
+  min-width: 44px;
+  &.button-link {
+    @extend %button-link-props;
+  }
+}
+
 .button-sm {
   @include button-size(sm);
 
@@ -119,6 +127,23 @@ button {
   &:active,
   &:hover {
     box-shadow: none;
+  }
+}
+
+.touchevents {
+  /* Enlarges the click area without enlarging the UI element */
+  .button-sm, 
+  .button-mini {
+    position: relative;
+    &:after {
+      content: '';
+      position: absolute;
+      top: -10px; 
+      bottom: -10px; 
+      left: -10px; 
+      right: -10px; 
+      min-height: 44px;
+    }
   }
 }
 

--- a/rocketbelt/components/forms/_forms.scss
+++ b/rocketbelt/components/forms/_forms.scss
@@ -187,7 +187,6 @@ fieldset {
 
 html {
   &.touchevents {
-    button,
     input,
     select {
       min-height: 44px;
@@ -385,7 +384,7 @@ textarea {
   .validation-message {
     font-size: font-size(-2);
   }
-}
+} 
 
 fieldset {
   margin: 0;

--- a/rocketbelt/components/radio-buttons/_radio-buttons-default.scss
+++ b/rocketbelt/components/radio-buttons/_radio-buttons-default.scss
@@ -4,7 +4,7 @@
 }
 
 input {
-  &.rb-checkbox[type='checkbox'] ,
+  &.rb-checkbox[type='checkbox'],
   &[type='radio'] {
     @extend %visuallyhidden;
 
@@ -112,6 +112,16 @@ input {
       }
     }
 
+    &:not(:checked) + label {
+      &:hover::before {
+        .touchevents & {
+          border-color: color(gray, plus2);
+          background-image: none;
+          background-color: white;
+        }
+      }
+    }
+    
     &[disabled] {
       &[checked] + label {
         &::before {

--- a/rocketbelt/tools/mixins/button/_button-size.scss
+++ b/rocketbelt/tools/mixins/button/_button-size.scss
@@ -7,16 +7,23 @@
 @mixin button-size($size: md) {
   @extend %button-static-props;
   $size: to_lower_case($size);
-  min-width: 8rem;
   @if $size == lg {
+    min-width: 8rem;
     padding: ms(-6) ms(1);
     font-size: font-size(0);
   }
   @else if $size == md {
+    min-width: 8rem;
     padding: ms(-8) ms(1);
     font-size: font-size(-1);
   }
+  @else if $size == mini {
+    min-width: 2.8rem;
+    padding: ms(-14) ms(1); 
+    font-size: font-size(-2);
+  }
   @else {
+    min-width: 6rem;
     padding: ms(-10) ms(1);
     font-size: font-size(-2);
   }

--- a/templates/exposition/homepage-components/index.pug
+++ b/templates/exposition/homepage-components/index.pug
@@ -1,14 +1,11 @@
 extends /_layout.pug
-
+ 
 block vars
   - var title = 'Homepage Components'
 
 block content
   article
     h1 Homepage Components
-    
-    a(name="docs-hp-layouts")
-    h2 Homepage Components
     <br/>
     div.docs-hp-layouts-controls-wrapper
       ul#docs-hp-layouts-controls.list-inline


### PR DESCRIPTION
FIXED - Updates in the templates folder were watched but not re-symlinked.

FIXED - Hover on checkboxes with touch devices misbehaved

ADDED - Mini button size

UPDATED - Added additional “invisible” spacing on mini and small buttons so that
click targets are larger on touch devices.