### PR TITLE
Improve tabcordion events

### DIFF
--- a/rocketbelt/components/tabcordions/rocketbelt.tabcordions.js
+++ b/rocketbelt/components/tabcordions/rocketbelt.tabcordions.js
@@ -38,7 +38,7 @@
 
             const eventData = { 'previousTarget': target, 'newTarget': adjacentTab };
             const event = new CustomEvent('rb.tabcordion.tabChanged', { detail: eventData });
-            $(this)[0].dispatchEvent(event);
+            $tabcordion.dispatchEvent(event);
 
             setActiveAndInactive(adjacentTab, $navlist);
           }
@@ -64,7 +64,7 @@
         if (currentTarget != $(this)[0]) {
           const eventData = { 'previousTarget': currentTarget, 'newTarget': $(this)[0] };
           const event = new CustomEvent('rb.tabcordion.tabChanged', { detail: eventData });
-          $(this)[0].dispatchEvent(event);
+          $tabcordion.dispatchEvent(event);
         }
 
         setActiveAndInactive(this, $navlist);

--- a/rocketbelt/components/tabcordions/rocketbelt.tabcordions.js
+++ b/rocketbelt/components/tabcordions/rocketbelt.tabcordions.js
@@ -36,11 +36,9 @@
             keyVent.preventDefault();
             adjacentTab.focus();
 
-            if (target != $(this)[0]) {
-              const eventData = { 'previousTarget': target, 'newTarget': adjacentTab };
-              const event = new CustomEvent('rb.tabcordion.tabChanged', { detail: eventData });
-              $(this)[0].dispatchEvent(event);
-            }
+            const eventData = { 'previousTarget': target, 'newTarget': adjacentTab };
+            const event = new CustomEvent('rb.tabcordion.tabChanged', { detail: eventData });
+            $(this)[0].dispatchEvent(event);
 
             setActiveAndInactive(adjacentTab, $navlist);
           }


### PR DESCRIPTION
This PR:

* Allows `rb.tabcordion.tabChanged` to be dispatched when a panel is accessed via keyboard navigation (There is already a conditional ensuring that the adjacentTab exists)
* Changes `rb.tabcordion.tabChanged` to be dispatched on the `.tabcordion` element instead of the `.tabcordion_trigger` element